### PR TITLE
[JORDAN] Middleware to add request_id

### DIFF
--- a/cmd/currency-converter/app/app.go
+++ b/cmd/currency-converter/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/rochajg/currency-converter/cmd/currency-converter/app/dependency"
+	"github.com/rochajg/currency-converter/cmd/currency-converter/app/middleware"
 	"github.com/rochajg/currency-converter/internal/infrastructure/database"
 )
 
@@ -20,7 +21,9 @@ func Start(r *gin.Engine) error {
 	return nil
 }
 
-func setupMiddlewares(r *gin.Engine) {}
+func setupMiddlewares(r *gin.Engine) {
+	r.Use(middleware.RequestID())
+}
 
 func setupDatabase() error {
 	return database.InitDB()

--- a/cmd/currency-converter/app/middleware/request_id.go
+++ b/cmd/currency-converter/app/middleware/request_id.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// requestIdMiddlewareWriter is a custom response writer that adds the request ID to the response headers
+type requestIdMiddlewareWriter struct {
+	gin.ResponseWriter
+	requestID string
+}
+
+// RequestID is a middleware function that adds a request ID to the context
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := uuid.New().String()
+		c.Set("request_id", requestID)
+
+		c.Writer = &requestIdMiddlewareWriter{
+			ResponseWriter: c.Writer,
+			requestID:      requestID,
+		}
+
+		c.Next()
+	}
+}
+
+// WriteHeader adds the request ID to the response headers
+func (m *requestIdMiddlewareWriter) WriteHeader(statusCode int) {
+	m.Header().Add("X-REQUEST-ID", m.requestID)
+	m.ResponseWriter.WriteHeader(statusCode)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.22.1 // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaC
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=


### PR DESCRIPTION
# Description

Funcionalidade que adiciona um _id_ unico pra cada request, a fim de facilitar a identificação de logs futuros e outros cenários.

Além do _request_id_ no contexto, também é retornado em todas as requests para facilitar a identificação em chamadas.

Exemplo de resposta:
![image](https://github.com/user-attachments/assets/50d4dbed-9a0c-4b99-a99c-d350c0d55312)